### PR TITLE
Adding autocomplete to password input elements

### DIFF
--- a/src/appier_extras/parts/admin/templates/fluid/account/new.html.tpl
+++ b/src/appier_extras/parts/admin/templates/fluid/account/new.html.tpl
@@ -24,11 +24,11 @@
             </div>
             <div class="input">
                 <input type="password" class="text-field full" name="password" placeholder="password"
-                        data-error="{{ errors.password }}" />
+                        autocomplete="new-password" data-error="{{ errors.password }}" />
             </div>
             <div class="input">
                 <input type="password" class="text-field full" name="password_confirm" placeholder="confirm password"
-                       data-error="{{ errors.password_confirm }}" />
+                       autocomplete="new-password" data-error="{{ errors.password_confirm }}" />
             </div>
             <div class="buttons">
                 <span class="button medium button-color button-blue" data-submit="true">Sign up</span>

--- a/src/appier_extras/parts/admin/templates/fluid/reset.html.tpl
+++ b/src/appier_extras/parts/admin/templates/fluid/reset.html.tpl
@@ -13,11 +13,11 @@
             <input type="hidden" name="reset_token" value="{{ reset_token }}" />
             <div class="input">
                 <input type="password" class="text-field full focus" name="password"
-                       value="{{ password }}" placeholder="password" />
+                       autocomplete="new-password" value="{{ password }}" placeholder="password" />
             </div>
             <div class="input">
                 <input type="password" class="text-field full" name="password_confirm"
-                       value="{{ password_confirm }}" placeholder="confirm password" />
+                       autocomplete="new-password" value="{{ password_confirm }}" placeholder="confirm password" />
             </div>
             <div class="buttons">
                 <span class="button medium button-color button-blue" data-submit="true">Reset</span>

--- a/src/appier_extras/parts/admin/templates/fluid/signin.html.tpl
+++ b/src/appier_extras/parts/admin/templates/fluid/signin.html.tpl
@@ -19,7 +19,8 @@
                        placeholder="username" />
             </div>
             <div class="input">
-                <input type="password" class="text-field full" name="password" placeholder="password" />
+                <input type="password" class="text-field full" name="password"
+                       autocomplete="current-password" placeholder="password" />
             </div>
             <div class="forgot">
                 <a href="{{ url_for('admin.recover') }}">Forgot your password?</a>

--- a/src/appier_extras/parts/admin/templates/static/signin.html.tpl
+++ b/src/appier_extras/parts/admin/templates/static/signin.html.tpl
@@ -19,7 +19,8 @@
                        placeholder="username" />
             </div>
             <div class="input">
-                <input type="password" class="text-field full" name="password" placeholder="password" />
+                <input type="password" class="text-field full" name="password"
+                       autocomplete="current-password" placeholder="password" />
             </div>
             <div class="forgot">
                 <a href="{{ url_for('admin.recover') }}">Forgot your password?</a>


### PR DESCRIPTION
Providing a smoother experience for users with password managers can help you make your web content more secure. 

The elements autocomplete="current-password" and autocomplete="new-password" enable password managers to automatically fill out a password field. 