### PR TITLE
Event Notify using Kafka

### DIFF
--- a/src/appier_extras/parts/admin/models/event.py
+++ b/src/appier_extras/parts/admin/models/event.py
@@ -237,20 +237,29 @@ class Event(base.Base):
             compression_type = appier.conf("KAFKA_COMPRESSION_TYPE", None)
             retries = appier.conf("KAFKA_RETRIES", 0)
             batch_size = appier.conf("KAFKA_BATCH_SIZE", 16384)
+            linger_ms = appier.conf("KAFKA_LINGER", 0)
+            connections_max_idle_ms = appier.conf("KAFKA_CONNECTIONS_MAX_IDLE", 540000)
+            max_request_size = appier.conf("KAFKA_MAX_REQUEST_SIZE", 1048576)
+            retry_backoff_ms = appier.conf("KAFKA_RETRY_BACKOFF", 100)
+            request_timeout_ms = appier.conf("KAFKA_REQUEST_TIMEOUT", 30000)
 
-            # TODO: add more options
             cls._producer = kafka.KafkaProducer(
                 bootstrap_servers=kafka_server,
                 client_id=client_id,
                 compression_type = compression_type,
                 retries = retries,
-                batch_size = batch_size
+                batch_size = batch_size,
+                linger_ms = linger_ms,
+                connections_max_idle_ms = connections_max_idle_ms,
+                max_request_size = max_request_size,
+                retry_backoff_ms = retry_backoff_ms,
+                request_timeout_ms = request_timeout_ms
             )
         
         topic = arguments["topic"] if arguments["topic"] else arguments["event"].split(".")[0]
         name = arguments["event"]
         origin = "ripe-core"
-        hostname = "ripe-core-1.platforme.com" # TODO: get this from somewhere else
+        hostname = "ripe-core-1.platforme.com" # TODO: get this from somewhere
         order = arguments["params"]["order"]
 
         cls._producer.send(topic, json.dumps(dict(

--- a/src/appier_extras/parts/admin/models/event.py
+++ b/src/appier_extras/parts/admin/models/event.py
@@ -37,12 +37,12 @@ __copyright__ = "Copyright (c) 2008-2020 Hive Solutions Lda."
 __license__ = "Apache License, Version 2.0"
 """ The license for the module """
 
-import json
 import datetime
-import re
+import fnmatch
+import json
+import socket
 
 import appier
-import socket
 
 from appier_extras import utils
 from appier_extras.parts.admin.models import base
@@ -126,7 +126,7 @@ class Event(base.Base):
         # verifies if the event name matches the name provided,
         # allowing for wildcards to be used in event handlers names
         for event in events:
-            if event.name == name or cls._match_wildcard(name, event.name):
+            if fnmatch.fnmatch(name, event.name):
                 event.name = name
                 event.notify(arguments=arguments)
 
@@ -281,18 +281,3 @@ class Event(base.Base):
         )
         event.save()
         return event
-
-    @classmethod
-    def _match_wildcard(cls, event_name, name):
-        # splits the provided events string into its parts,
-        # using namespaces defined around the dot character
-        event_l = event_name.split(".")
-        name_l = name.split(".")
-
-        # iterates over the set of parts in the event list
-        # to validate it against the event name using namespace
-        # and not complete string validation
-        for name_i, name_p in enumerate(name_l):
-            if name_p == "*": return True
-            if name_p == event_l[name_i]: continue
-            return False

--- a/src/appier_extras/parts/admin/models/event.py
+++ b/src/appier_extras/parts/admin/models/event.py
@@ -42,6 +42,7 @@ import datetime
 import re
 
 import appier
+import socket
 
 from appier_extras import utils
 from appier_extras.parts.admin.models import base
@@ -259,7 +260,7 @@ class Event(base.Base):
         topic = arguments["topic"] if arguments["topic"] else arguments["event"].split(".")[0]
         name = arguments["event"]
         origin = "ripe-core"
-        hostname = "ripe-core-1.platforme.com" # TODO: get this from somewhere
+        hostname = socket.gethostname()
         order = arguments["params"]["order"]
 
         cls._producer.send(topic, json.dumps(dict(

--- a/src/appier_extras/parts/admin/models/event.py
+++ b/src/appier_extras/parts/admin/models/event.py
@@ -267,7 +267,7 @@ class Event(base.Base):
             hostname = hostname,
             datatype = "json",
             timestamp = datetime.datetime.now(),
-            order = json.dumps(payload)
+            payload = json.dumps(payload)
         )).encode("utf-8"))
         producer.flush()
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Decisions | Event matching logic changed, allowing the matching with events with wildcards in the name. For example, when an event with the name `order.create` is received, it will match with event handlers with the name `order.*`. <br> A Kafka Producer client is created for each notification, with a set of configurations provided by the appier.json file. The notification is instantly flushed to the kafka broker. |
| Animated GIF | Event: <br><img width="1414" alt="Screenshot 2020-09-04 at 16 00 06" src="https://user-images.githubusercontent.com/25725586/92253691-bcb36f00-eec7-11ea-8eee-9e3a1e0acc35.png"><br> Creating an order and the kafka consumer running on the right receives the event: <br>![Sep-04-2020 14-31-03](https://user-images.githubusercontent.com/25725586/92244810-50cb0980-eebb-11ea-95fa-2065d6955288.gif) <br> Event received by a kafka consumer: <br> <img width="1262" alt="Screenshot 2020-09-04 at 15 57 38" src="https://user-images.githubusercontent.com/25725586/92253424-621a1300-eec7-11ea-8368-16afaf018e44.png">|


