### PR TITLE
Adding event name to permutations

### DIFF
--- a/src/appier_extras/parts/admin/models/event.py
+++ b/src/appier_extras/parts/admin/models/event.py
@@ -301,4 +301,5 @@ class Event(base.Base):
         for name_i in range(len(names_a)):
             name_join = ".".join([n for n in names_a[0:name_i + 1]])
             names.append("%s.%s" % (name_join, wildcard))
+        names.append(name)
         return names


### PR DESCRIPTION
| - | - |
| --- | --- |
| Problem | The permutations was resulting in all the events possible except the original one, making matching to the original one impossible.|
| Decisions | Adding original event name to permutations. |
| Screenshots | **Before**:<br><img width="1482" alt="Screenshot 2020-10-26 at 15 24 49" src="https://user-images.githubusercontent.com/25725586/97192123-8693bc80-179f-11eb-915f-6fd120b01b3d.png"><br>**After**:<br><img width="1477" alt="Screenshot 2020-10-26 at 15 24 34" src="https://user-images.githubusercontent.com/25725586/97192016-682dc100-179f-11eb-900c-c50e80c52296.png">|


