### PR TITLE
#401 Returning to previous page instead of sign in page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Removed nightly build from `.travis.yml`
+* Recover password with link to return to the previous page instead of the sign in page
 
 ## [0.24.7] - 2022-05-02
 

--- a/src/appier_extras/parts/admin/templates/fluid/recover.html.tpl
+++ b/src/appier_extras/parts/admin/templates/fluid/recover.html.tpl
@@ -2,6 +2,8 @@
 {% block title %}Recover{% endblock %}
 {% block body_style %}{{ super() }} {% if background %}background:url({{ background }});{% endif %}{% endblock %}
 {% block content %}
+{% set param_next = request.args.get('next')[0] %}
+{% set url_signin = url_for('admin.login', next = param_next) if param_next else url_for('admin.login') %}
     <div class="login-panel {% if error %}login-panel-message{% endif %}">
         <h1>Recover password</h1>
         <h3>Use your username or email</h3>
@@ -22,7 +24,7 @@
             </div>
             <div class="new">
                 <span>or</span>
-                <a href="javascript:history.back()">return to previous page</a>
+                <a href="{{ url_signin }}">return to sign in</a>
             </div>
         </form>
     </div>

--- a/src/appier_extras/parts/admin/templates/fluid/recover.html.tpl
+++ b/src/appier_extras/parts/admin/templates/fluid/recover.html.tpl
@@ -2,8 +2,7 @@
 {% block title %}Recover{% endblock %}
 {% block body_style %}{{ super() }} {% if background %}background:url({{ background }});{% endif %}{% endblock %}
 {% block content %}
-{% set param_next = request.args.get("next")[0] %}
-{% set url_signin = url_for("admin.login", next = param_next) if param_next else url_for("admin.login") %}
+{% set next = request.args.get("next")[0] if request.args.get("next")[0] else None %}
     <div class="login-panel {% if error %}login-panel-message{% endif %}">
         <h1>Recover password</h1>
         <h3>Use your username or email</h3>
@@ -24,7 +23,7 @@
             </div>
             <div class="new">
                 <span>or</span>
-                <a href="{{ url_signin }}">return to sign in</a>
+                <a href="{{ url_for("admin.login", next = next) }}">return to sign in</a>
             </div>
         </form>
     </div>

--- a/src/appier_extras/parts/admin/templates/fluid/recover.html.tpl
+++ b/src/appier_extras/parts/admin/templates/fluid/recover.html.tpl
@@ -2,8 +2,8 @@
 {% block title %}Recover{% endblock %}
 {% block body_style %}{{ super() }} {% if background %}background:url({{ background }});{% endif %}{% endblock %}
 {% block content %}
-{% set param_next = request.args.get('next')[0] %}
-{% set url_signin = url_for('admin.login', next = param_next) if param_next else url_for('admin.login') %}
+{% set param_next = request.args.get("next")[0] %}
+{% set url_signin = url_for("admin.login", next = param_next) if param_next else url_for("admin.login") %}
     <div class="login-panel {% if error %}login-panel-message{% endif %}">
         <h1>Recover password</h1>
         <h3>Use your username or email</h3>

--- a/src/appier_extras/parts/admin/templates/fluid/recover.html.tpl
+++ b/src/appier_extras/parts/admin/templates/fluid/recover.html.tpl
@@ -22,7 +22,7 @@
             </div>
             <div class="new">
                 <span>or</span>
-                <a href="{{ url_for('admin.login') }}">return to sign in</a>
+                <a href="javascript:history.back()">return to previous page</a>
             </div>
         </form>
     </div>

--- a/src/appier_extras/parts/admin/templates/fluid/signin.html.tpl
+++ b/src/appier_extras/parts/admin/templates/fluid/signin.html.tpl
@@ -2,8 +2,7 @@
 {% block title %}Login{% endblock %}
 {% block body_style %}{{ super() }} {% if background %}background:url({{ background }});{% endif %}{% endblock %}
 {% block content %}
-{% set param_next = request.args.get("next")[0] %}
-{% set url_recover = url_for("admin.recover", next = param_next) if param_next else url_for("admin.recover") %}
+{% set next = request.args.get("next")[0] if request.args.get("next")[0] else None %}
     <div class="login-panel {% if error %}login-panel-message{% endif %}">
         {% if owner.logo_url %}
             <img class="login-logo" src="{{ owner.logo_url }}" />
@@ -25,7 +24,7 @@
                        autocomplete="current-password" placeholder="password" />
             </div>
             <div class="forgot">
-                <a href="{{ url_recover }}">Forgot your password?</a>
+                <a href="{{ url_for('admin.login', next=next) }}">Forgot your password?</a>
             </div>
             <div class="buttons">
                 <span class="button medium button-color button-blue" data-submit="true">

--- a/src/appier_extras/parts/admin/templates/fluid/signin.html.tpl
+++ b/src/appier_extras/parts/admin/templates/fluid/signin.html.tpl
@@ -2,6 +2,8 @@
 {% block title %}Login{% endblock %}
 {% block body_style %}{{ super() }} {% if background %}background:url({{ background }});{% endif %}{% endblock %}
 {% block content %}
+{% set param_next = request.args.get('next')[0] %}
+{% set url_recover = url_for('admin.recover', next = param_next) if param_next else url_for('admin.recover') %}
     <div class="login-panel {% if error %}login-panel-message{% endif %}">
         {% if owner.logo_url %}
             <img class="login-logo" src="{{ owner.logo_url }}" />
@@ -23,7 +25,7 @@
                        autocomplete="current-password" placeholder="password" />
             </div>
             <div class="forgot">
-                <a href="{{ url_for('admin.recover') }}">Forgot your password?</a>
+                <a href="{{ url_recover }}">Forgot your password?</a>
             </div>
             <div class="buttons">
                 <span class="button medium button-color button-blue" data-submit="true">

--- a/src/appier_extras/parts/admin/templates/fluid/signin.html.tpl
+++ b/src/appier_extras/parts/admin/templates/fluid/signin.html.tpl
@@ -2,8 +2,8 @@
 {% block title %}Login{% endblock %}
 {% block body_style %}{{ super() }} {% if background %}background:url({{ background }});{% endif %}{% endblock %}
 {% block content %}
-{% set param_next = request.args.get('next')[0] %}
-{% set url_recover = url_for('admin.recover', next = param_next) if param_next else url_for('admin.recover') %}
+{% set param_next = request.args.get("next")[0] %}
+{% set url_recover = url_for("admin.recover", next = param_next) if param_next else url_for("admin.recover") %}
     <div class="login-panel {% if error %}login-panel-message{% endif %}">
         {% if owner.logo_url %}
             <img class="login-logo" src="{{ owner.logo_url }}" />


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-robin-revamp/issues/401 - This is also reproducible for any oauth login flow -- instead of returning to sign in page we should return to the previous page that has all the parameters like `?next=...` necessary to not lose the login flow. |
| Decisions | - Recover password with link to return to the previous page instead of the sign in page |
