### PR TITLE
Timeout limit for HTTP notifications

### DIFF
--- a/src/appier_extras/parts/admin/models/event.py
+++ b/src/appier_extras/parts/admin/models/event.py
@@ -182,10 +182,11 @@ class Event(base.Base):
     def notify_http(self, arguments={}):
         cls = self.__class__
         url = arguments.get("url", None)
+        timeout = arguments.get("timeout", None)
         retries = arguments.get("retries", 3)
         logger = appier.get_logger()
         logger.debug("Running HTTP notification for '%s' ..." % url)
-        return cls._retry(lambda: appier.post(url, data_j=arguments), count=retries)
+        return cls._retry(lambda: appier.post(url, timeout=timeout, data_j=arguments), count=retries)
 
     def notify_mailme(self, arguments={}):
         cls = self.__class__


### PR DESCRIPTION
Allow the timeout limit to be specified when sending events through HTTP.

This way, it is possible to avoid being impacted by the performance of external services when they are not ready to receive events. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced HTTP notification method with a new `timeout` parameter for improved request control.

- **Bug Fixes**
	- Adjusted the notification process to dynamically retrieve the `timeout` value from the arguments, ensuring correct execution timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->